### PR TITLE
Chore/unit test

### DIFF
--- a/BACK/my_docker_django_app/my_docker_django_app/tests/test_basic.py
+++ b/BACK/my_docker_django_app/my_docker_django_app/tests/test_basic.py
@@ -1,0 +1,5 @@
+from django.test import SimpleTestCase
+
+class BasicTest(SimpleTestCase):
+    def test_basic_math(self):
+        self.assertEqual(1 + 1, 2) 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+tasks:
+  start:
+    desc: Démarre tous les conteneurs
+    cmds:
+      - docker-compose up -d
+
+  stop:
+    desc: Arrête tous les conteneurs
+    cmds:
+      - docker-compose down
+
+  install:
+    desc: Installe les dépendances pour le frontend et le backend
+    cmds:
+      - docker-compose exec frontend npm install
+      - docker-compose exec backend pip install -r requirements.txt
+
+  test-unit:
+    desc: Lance les tests unitaires du backend
+    cmds:
+      - docker-compose exec backend python manage.py test my_docker_django_app.tests.test_basic
+
+  logs:
+    desc: Affiche les logs des conteneurs
+    cmds:
+      - docker-compose logs -f
+
+  build:
+    desc: Reconstruit les images Docker
+    cmds:
+      - docker-compose build 


### PR DESCRIPTION
Création du premier test unitaire 
depuis l'extérieur de container : ➜  `docker-compose exec backend python manage.py test my_docker_django_app.tests.test_basic.BasicTest.test_basic_math`

Ajout de Taskfile qui permet l'automatisation de command tel que 

- le start des container : task install 
- le lancement des tests unit : task test-unit 
- le stop des container : task stop 